### PR TITLE
NAB-26 Add default implementation of LeakCanary

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -242,6 +242,8 @@ dependencies {
     implementation Deps.androidx_lifecycle_runtime
     implementation Deps.google_material
 
+    debugImplementation Deps.leakcanary
+
     androidTestImplementation Deps.uiautomator
 
     androidTestImplementation Deps.espresso_core, {

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -32,6 +32,8 @@ private object Versions {
     const val tools_test_rules = "1.1.0"
     const val tools_test_runner = "1.1.0"
     const val uiautomator = "2.2.0"
+
+    const val leakcanary = "2.0-beta-3"
 }
 
 // Synchronized dependencies used by (some) modules
@@ -123,4 +125,6 @@ object Deps {
     const val tools_test_rules = "androidx.test:rules:${Versions.tools_test_rules}"
     const val tools_test_runner = "androidx.test:runner:${Versions.tools_test_runner}"
     const val uiautomator = "androidx.test.uiautomator:uiautomator:${Versions.uiautomator}"
+
+    const val leakcanary = "com.squareup.leakcanary:leakcanary-android:${Versions.leakcanary}"
 }


### PR DESCRIPTION
I just added the dependency cause LeakCanary 2 now does not require to add any code to the Application class if there's no need for any custom changes:

https://square.github.io/leakcanary/faq/#how-does-leakcanary-get-installed-by-only-adding-a-dependency