### PR TITLE
NAB-30 Add a new session when there are no active sessions

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/components/Core.kt
@@ -8,6 +8,7 @@ import android.content.Context
 import android.content.SharedPreferences
 import android.preference.PreferenceManager
 import mozilla.components.browser.icons.BrowserIcons
+import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.session.storage.SessionStorage
 import mozilla.components.browser.state.store.BrowserStore
@@ -77,6 +78,9 @@ class Core(private val context: Context) {
         SessionManager(engine, store).apply {
             sessionStorage.restore()?.let { snapshot -> restore(snapshot) }
 
+            if (size == 0) {
+                add(Session("about:blank"), selected = true)
+            }
             sessionStorage.autoSave(this)
                 .periodicallyInForeground(interval = 30, unit = TimeUnit.SECONDS)
                 .whenGoingToBackground()

--- a/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/tabs/TabsTrayFragment.kt
@@ -11,6 +11,8 @@ import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_tabstray.tabsPanel
 import kotlinx.android.synthetic.main.fragment_tabstray.tabsTray
+import mozilla.components.browser.session.Session
+import mozilla.components.browser.session.SessionManager
 import mozilla.components.feature.tabs.tabstray.TabsFeature
 import mozilla.components.support.base.feature.BackHandler
 import org.mozilla.reference.browser.R
@@ -20,7 +22,7 @@ import org.mozilla.reference.browser.ext.requireComponents
 /**
  * A fragment for displaying the tabs tray.
  */
-class TabsTrayFragment : Fragment(), BackHandler {
+class TabsTrayFragment : Fragment(), BackHandler, SessionManager.Observer {
     private var tabsFeature: TabsFeature? = null
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
@@ -42,12 +44,30 @@ class TabsTrayFragment : Fragment(), BackHandler {
         super.onStart()
 
         tabsFeature?.start()
+        requireComponents.core.sessionManager.register(this)
     }
 
     override fun onStop() {
         super.onStop()
 
         tabsFeature?.stop()
+        requireComponents.core.sessionManager.unregister(this)
+    }
+
+    override fun onSessionRemoved(session: Session) {
+        super.onSessionRemoved(session)
+        requireComponents.core.sessionManager.apply {
+            if (size == 0) {
+                add(Session("about:blank"), selected = true)
+            }
+        }
+    }
+
+    override fun onAllSessionsRemoved() {
+        super.onAllSessionsRemoved()
+        requireComponents.core.sessionManager.apply {
+            add(Session("about:blank"), selected = true)
+        }
     }
 
     override fun onBackPressed(): Boolean {


### PR DESCRIPTION
This is to fix the issue where the tab counter icon shows '0'. So now we always add a session when there is none.