### PR TITLE
Fix url hint padding

### DIFF
--- a/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/BaseBrowserFragment.kt
@@ -20,7 +20,7 @@ import mozilla.components.feature.prompts.PromptFeature
 import mozilla.components.feature.session.FullScreenFeature
 import mozilla.components.feature.session.SessionFeature
 import mozilla.components.feature.session.SwipeRefreshFeature
-import mozilla.components.feature.session.WindowFeature
+import mozilla.components.feature.tabs.WindowFeature
 import mozilla.components.feature.sitepermissions.SitePermissionsFeature
 import mozilla.components.support.base.feature.BackHandler
 import mozilla.components.support.base.feature.PermissionsFeature
@@ -142,7 +142,9 @@ abstract class BaseBrowserFragment : Fragment(), BackHandler, UserInteractionHan
             view = view)
 
         windowFeature.set(
-            feature = WindowFeature(requireComponents.core.sessionManager),
+            feature = WindowFeature(
+                requireComponents.core.store,
+                requireComponents.useCases.tabsUseCases),
             owner = this,
             view = view
         )

--- a/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/CustomTabsIntegration.kt
@@ -41,7 +41,7 @@ class CustomTabsIntegration(
             logger.warn("The session for this ID, no longer exists. Finishing activity.")
             activity?.finish()
         }
-        toolbar.urlBoxView = null
+        toolbar.display.setUrlBackground(null)
     }
 
     private val menuToolbar by lazy {

--- a/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
+++ b/app/src/main/java/org/mozilla/reference/browser/browser/ToolbarIntegration.kt
@@ -6,7 +6,6 @@ package org.mozilla.reference.browser.browser
 
 import android.content.Context
 import android.content.Intent
-import android.view.View
 import androidx.fragment.app.FragmentManager
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -18,6 +17,7 @@ import mozilla.components.browser.menu.item.BrowserMenuSwitch
 import mozilla.components.browser.menu.item.SimpleBrowserMenuItem
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.concept.storage.HistoryStorage
 import mozilla.components.feature.pwa.WebAppUseCases
 import mozilla.components.feature.session.SessionUseCases
@@ -78,7 +78,7 @@ class ToolbarIntegration(
         listOf(
             menuToolbar,
             SimpleBrowserMenuItem("New Tab") {
-                tabsUseCases.addTab.invoke("about:blank")
+                tabsUseCases.addTab.invoke("")
             },
             SimpleBrowserMenuItem("Share") {
                 val url = sessionManager.selectedSession?.url ?: ""
@@ -124,22 +124,21 @@ class ToolbarIntegration(
     private val menuBuilder = BrowserMenuBuilder(menuItems)
 
     init {
-        toolbar.displayTrackingProtectionIcon = true
-        toolbar.displaySeparatorView = true
-        toolbar.setMenuBuilder(menuBuilder)
+        toolbar.display.indicators = listOf(DisplayToolbar.Indicators.SECURITY)
+        toolbar.display.displayIndicatorSeparator = true
+        toolbar.display.menuBuilder = menuBuilder
         if (toolbarEditMode) {
             toolbar.editMode()
         }
-        toolbar.hint = context.getString(R.string.toolbar_hint)
+        toolbar.display.hint = context.getString(R.string.toolbar_hint)
+        toolbar.edit.hint = context.getString(R.string.toolbar_hint)
 
         ToolbarAutocompleteFeature(toolbar).apply {
             addHistoryStorageProvider(historyStorage)
             addDomainProvider(shippedDomainsProvider)
         }
 
-        toolbar.urlBoxView = View(context).apply {
-            background = context.resources.getDrawable(R.drawable.url_background, context.theme)
-        }
+        toolbar.display.setUrlBackground(context.resources.getDrawable(R.drawable.url_background, context.theme))
     }
 
     private val toolbarFeature: ToolbarFeature = ToolbarFeature(

--- a/app/src/main/res/drawable/url_background.xml
+++ b/app/src/main/res/drawable/url_background.xml
@@ -2,15 +2,7 @@
 <!-- This Source Code Form is subject to the terms of the Mozilla Public
    - License, v. 2.0. If a copy of the MPL was not distributed with this
    - file, You can obtain one at http://mozilla.org/MPL/2.0/. -->
-<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item
-        android:bottom="8dp"
-        android:left="8dp"
-        android:right="0dp"
-        android:top="8dp">
-        <shape>
-            <solid android:color="@color/toolbarUrlBoxColor" />
-            <corners android:radius="4dp" />
-        </shape>
-    </item>
-</layer-list>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/toolbarUrlBoxColor" />
+    <corners android:radius="4dp"/>
+</shape>

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -21,7 +21,7 @@ private object Versions {
     const val androidx_lifecycle = "2.2.0-alpha05"
     const val android_gradle_plugin = "3.4.1"
 
-    const val mozilla_android_components = "18.0.0"
+    const val mozilla_android_components = "20.0.0"
 
     const val thirdparty_sentry = "1.7.10"
 

--- a/freshtab/src/main/java/com/cliqz/browser/freshtab/FreshTabFeature.kt
+++ b/freshtab/src/main/java/com/cliqz/browser/freshtab/FreshTabFeature.kt
@@ -6,6 +6,7 @@ import mozilla.components.browser.session.Session
 import mozilla.components.browser.session.SessionManager
 import mozilla.components.concept.engine.EngineView
 import mozilla.components.browser.toolbar.BrowserToolbar
+import mozilla.components.browser.toolbar.display.DisplayToolbar
 import mozilla.components.concept.awesomebar.AwesomeBar
 import mozilla.components.concept.toolbar.Toolbar
 
@@ -93,11 +94,11 @@ class FreshTabFeature(
             if (showFreshTab) {
                 freshTab.visibility = View.VISIBLE
                 engineView.asView().visibility = View.GONE
-                toolbar.displaySiteSecurityIcon = false
+                toolbar.display.indicators = emptyList()
             } else {
                 freshTab.visibility = View.GONE
                 engineView.asView().visibility = View.VISIBLE
-                toolbar.displaySiteSecurityIcon = true
+                toolbar.display.indicators = listOf(DisplayToolbar.Indicators.SECURITY)
             }
     }
 


### PR DESCRIPTION
Upgrading the components version fixes our problem where there was no padding on the url text

Before
![device-2019-11-07-110942](https://user-images.githubusercontent.com/6861614/68380775-c73e9400-0150-11ea-83a6-08db7e5764b8.png)

After
![device-2019-11-07-111127](https://user-images.githubusercontent.com/6861614/68380780-cc034800-0150-11ea-8c23-8ceee28a9c5f.png)

Also, the library upgrade doesn't seem to be breaking any of our changes.
